### PR TITLE
Add counter for each link usage

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
       </form>
 
       <div id="responseField">
-
+        <div id="counter"></div>
       </div>
 
     </div>

--- a/public/helperFunctions.js
+++ b/public/helperFunctions.js
@@ -1,21 +1,28 @@
+const updateCounter = () => {
+  let counterElement = document.getElementById('counter');
+  let count = parseInt(counterElement.innerText) || 0;
+  counterElement.innerText = count + 1;
+}
+
 // manipulate responseField to render a formatted and appropriate message
 const renderResponse = (res) => {
-    if(res.errors){
-      responseField.innerHTML = "<p>Sorry, couldn't format your URL.</p><p>Try again.</p>"
-    } else {
-      responseField.innerHTML = `<p>Your shortened url is: </p><p> ${res.shortUrl} </p>`
-    }
+  updateCounter();
+  if(res.errors){
+    responseField.innerHTML = "<p>Sorry, couldn't format your URL.</p><p>Try again.</p>"
+  } else {
+    responseField.innerHTML = `<p>Your shortened url is: </p><p> ${res.shortUrl} </p>`
   }
-  
-  // manipulate responseField to render an unformatted response
-  const renderRawResponse = (res) => {
-    if(res.errors){
-      responseField.innerHTML = "<p>Sorry, couldn't format your URL.</p><p>Try again.</p>"
-    } else {
-      let structuredRes = JSON.stringify(res).replace(/,/g, ", \n")
-      structuredRes = `<pre>${structuredRes}</pre>`
-  
-      responseField.innerHTML = `${structuredRes}`
-    }
+}
+
+// manipulate responseField to render an unformatted response
+const renderRawResponse = (res) => {
+  updateCounter();
+  if(res.errors){
+    responseField.innerHTML = "<p>Sorry, couldn't format your URL.</p><p>Try again.</p>"
+  } else {
+    let structuredRes = JSON.stringify(res).replace(/,/g, ", \n")
+    structuredRes = `<pre>${structuredRes}</pre>`
+
+    responseField.innerHTML = `${structuredRes}`
   }
-  
+}

--- a/public/main.js
+++ b/public/main.js
@@ -1,13 +1,12 @@
-// Information to reach API
 const apiKey = 'f44beb51cb0b414ca4b1f203be60ff03';
 const url = 'https://api.rebrandly.com/v1/links';
 
-// Some page elements
 const inputField = document.querySelector('#input');
 const shortenButton = document.querySelector('#shorten');
 const responseField = document.querySelector('#responseField');
 
-// AJAX functions
+let counter = 0;
+
 const shortenUrl = () => {
   const urlToShorten = inputField.value;
   const data = JSON.stringify({destination: urlToShorten});
@@ -17,17 +16,17 @@ const shortenUrl = () => {
   
   xhr.onreadystatechange = () => {
     if (xhr.readyState === XMLHttpRequest.DONE) {
-  		renderResponse(xhr.response);
-		}
+      renderResponse(xhr.response);
+      counter++;
+      document.getElementById('counter').innerText = `Link usage count: ${counter}`;
+    }
   }
   xhr.open('POST', url);
   xhr.setRequestHeader('Content-type', 'application/json');
-	xhr.setRequestHeader('apikey', apiKey);
+  xhr.setRequestHeader('apikey', apiKey);
   xhr.send(data);
 }
 
-
-// Clear page and call AJAX functions
 const displayShortUrl = (event) => {
   event.preventDefault();
   while(responseField.firstChild){


### PR DESCRIPTION
Related to #1

Add a counter for each link that stores the total count of times it has been used.

* **index.html**
  - Add a new `div` element with id `counter` inside the `responseField` div.

* **public/helperFunctions.js**
  - Add a new function `updateCounter` that increments the counter for each link usage.
  - Call `updateCounter` inside `renderResponse` and `renderRawResponse` functions.

* **public/main.js**
  - Add a new variable `counter` to store the count of link usage.
  - Initialize `counter` to 0.
  - Increment `counter` inside `shortenUrl` function.
  - Display the counter value inside the `responseField` div.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Iltwats/ByteSize/issues/1?shareId=75279791-f1df-47c5-a239-cfe09a927b58).